### PR TITLE
fix: prevent spaces in email input

### DIFF
--- a/lib/features/auth/screen/login_screen.dart
+++ b/lib/features/auth/screen/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_boilerplate_hng11/features/auth/providers/auth.provider.dart';
 import 'package:flutter_boilerplate_hng11/features/auth/screen/webview_page.dart';
 import 'package:flutter_boilerplate_hng11/utils/context_extensions.dart';
@@ -191,6 +192,9 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                     keyboardType: TextInputType.emailAddress,
                     hintText: AppLocalizations.of(context)!.enterEmail,
                     validator: (v) => Validators.emailValidator(v, context),
+                    inputFormatters: [
+                      FilteringTextInputFormatter.deny(RegExp(r'\s')),
+                    ],
                   ),
                   SizedBox(
                     height: 16.h,
@@ -199,7 +203,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                     label: AppLocalizations.of(context)!.password,
                     controller: LoginScreen._passwordController,
                     hintText: AppLocalizations.of(context)!.password,
-                    validator: (v) => Validators.passwordValidator(v,context),
+                    validator: (v) => Validators.passwordValidator(v, context),
                   ),
                   SizedBox(
                     height: 16.h,

--- a/lib/features/auth/screen/single_user_signup.dart
+++ b/lib/features/auth/screen/single_user_signup.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_boilerplate_hng11/features/auth/widgets/loading_overlay.dart';
 import 'package:flutter_boilerplate_hng11/utils/context_extensions.dart';
 import 'package:flutter_boilerplate_hng11/utils/custom_text_style.dart';
@@ -126,14 +127,14 @@ class SingleUserSignUpScreen extends ConsumerWidget {
                       controller: SingleUserSignUpScreen.firstNameController,
                       hintText: localizations.enterFirstName,
                       focusedBorderColor: GlobalColors.orange,
-                      validator: (v) => Validators.nameValidator(v,context),
+                      validator: (v) => Validators.nameValidator(v, context),
                     ),
                     CustomTextField(
                       label: localizations.lastName,
                       controller: lastNameController,
                       hintText: localizations.enterLastName,
                       focusedBorderColor: GlobalColors.orange,
-                      validator: (v) => Validators.nameValidator(v,context),
+                      validator: (v) => Validators.nameValidator(v, context),
                     ),
                     CustomTextField(
                       label: localizations.email,
@@ -141,6 +142,9 @@ class SingleUserSignUpScreen extends ConsumerWidget {
                       hintText: localizations.enterEmail,
                       focusedBorderColor: GlobalColors.orange,
                       validator: (v) => Validators.emailValidator(v, context),
+                      inputFormatters: [
+                        FilteringTextInputFormatter.deny(RegExp(r'\s')),
+                      ],
                     ),
                     PasswordTextField(
                       label: localizations.password,
@@ -148,7 +152,8 @@ class SingleUserSignUpScreen extends ConsumerWidget {
                       hintText: localizations.createPassword,
                       obscureText: true,
                       focusedBorderColor: GlobalColors.orange,
-                      validator: (v) => Validators.passwordValidator(v,context),
+                      validator: (v) =>
+                          Validators.passwordValidator(v, context),
                     ),
                     SizedBox(height: 10.h),
                     CustomButton(

--- a/lib/utils/widgets/custom_text_field.dart
+++ b/lib/utils/widgets/custom_text_field.dart
@@ -1,5 +1,6 @@
 //custom_textfield.dart
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_boilerplate_hng11/utils/global_colors.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
@@ -22,6 +23,7 @@ class CustomTextField extends StatelessWidget {
   final Color? borderColor;
   final Color? focusedBorderColor;
   final FocusNode? focusNode;
+  final List<TextInputFormatter>? inputFormatters;
 
   const CustomTextField({
     super.key,
@@ -44,6 +46,7 @@ class CustomTextField extends StatelessWidget {
     this.focusedBorderColor,
     this.focusNode,
     this.onchanged,
+    this.inputFormatters,
   });
 
   @override
@@ -78,6 +81,7 @@ class CustomTextField extends StatelessWidget {
             obscureText: obscureText ?? false,
             maxLines: maxLines ?? 1,
             validator: validator,
+            inputFormatters: inputFormatters,
             focusNode: focusNode,
             onChanged: onchanged,
             textInputAction: TextInputAction.next,


### PR DESCRIPTION
This PR addresses an issue where users could accidentally enter spaces in the email field on the login or sign up screen.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
## Screenshots (if appropriate)
